### PR TITLE
fix: raise on missing graph paths

### DIFF
--- a/kurra/utils.py
+++ b/kurra/utils.py
@@ -64,38 +64,35 @@ def guess_format_from_data(rdf: str) -> str | None:
 
 def load_graph(graph_path_or_str: Union[Graph, Path, str], recursive=False) -> Graph:
     """
-    Presents an RDFLib Graph object from a pre-existing Graph, a pickle file, an RDF file or directory of files or RDF
-    data in a string
+    Presents an RDFLib Graph object from a pre-existing Graph, a pickle-cached RDF file, an RDF file or directory of
+    files, or RDF data in a string. Missing filesystem paths raise FileNotFoundError.
     """
     # Pre-existing Graph
     if isinstance(graph_path_or_str, Graph):
         return graph_path_or_str
 
-    # Pickle file
+    # Serialized RDF file or dir of files, optionally using a sibling pickle cache
     if isinstance(graph_path_or_str, Path):
         if graph_path_or_str.is_file():
             pkl_path = graph_path_or_str.with_suffix(".pkl")
             if pkl_path.is_file():
                 return pickle.load(open(pkl_path, "rb"))
-
-    # Serialized RDF file or dir of files
-    if isinstance(graph_path_or_str, Path):
-        if Path(graph_path_or_str).is_file():
             if str(graph_path_or_str).endswith(".trig") or str(
                 graph_path_or_str
             ).endswith(".jsonld"):
                 return Dataset().parse(str(graph_path_or_str))
             return Graph().parse(graph_path_or_str)
-        elif Path(graph_path_or_str).is_dir():
+        elif graph_path_or_str.is_dir():
             g = Graph()
             if recursive:
-                gl = Path(graph_path_or_str).rglob("*.ttl")
+                gl = graph_path_or_str.rglob("*.ttl")
             else:
-                gl = Path(graph_path_or_str).glob("*.ttl")
+                gl = graph_path_or_str.glob("*.ttl")
             for f in gl:
                 if f.is_file():
                     g.parse(f)
             return g
+        raise FileNotFoundError(f"Graph path does not exist: {graph_path_or_str}")
 
     # A remote file via HTTP
     elif isinstance(graph_path_or_str, str) and graph_path_or_str.startswith("http"):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 import json
+import pickle
 from pathlib import Path
 
+import pytest
 from rdflib import Graph
 from rdflib.compare import isomorphic
 
@@ -117,6 +119,42 @@ def test_load_graph():
     )
 
     assert len(g5) > 10
+
+
+def test_load_graph_missing_path():
+    missing_path = Path(__file__).parent / "file" / "does-not-exist.ttl"
+
+    with pytest.raises(FileNotFoundError, match="Graph path does not exist"):
+        load_graph(missing_path)
+
+
+def test_load_graph_prefers_pickle_cache_for_existing_file(tmp_path):
+    rdf_graph = Graph()
+    rdf_graph.parse(
+        data="""
+            PREFIX ex: <http://example.com/>
+
+            ex:a ex:b ex:c .
+            """
+    )
+
+    pickle_graph = Graph()
+    pickle_graph.parse(
+        data="""
+            PREFIX ex: <http://example.com/>
+
+            ex:x ex:y ex:z .
+            """
+    )
+
+    rdf_path = tmp_path / "cached.ttl"
+    rdf_path.write_text(rdf_graph.serialize(format="turtle"), encoding="utf-8")
+    pickle_path = rdf_path.with_suffix(".pkl")
+    pickle_path.write_bytes(pickle.dumps(pickle_graph))
+
+    loaded_graph = load_graph(rdf_path)
+
+    assert isomorphic(loaded_graph, pickle_graph)
 
 
 def test_load_graph_dir():


### PR DESCRIPTION
This PR fixes the `load_graph()` function where a non-existent file returns `None` instead of `Graph` or raises an error. 

The fix: raise a `FileNotFoundError` when all handling of `Path` fails.

Reminder for myself: once this is merged and released, make a release in prezmanifest.